### PR TITLE
Fix ft_strcpy label names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore build artifacts
+*.o

--- a/strcpy.asm
+++ b/strcpy.asm
@@ -5,9 +5,9 @@
 ft_strcpy:
         mov     rax, rdi
         test    rdi, rdi
-        je      ft_strcpy_null
+        je      .ft_strcpy_null
         test    rsi, rsi
-        je      ft_strcpy_null
+        je      .ft_strcpy_null
 .ft_strcpy_loop:
         mov     bl, byte ptr [rsi]
         mov     byte ptr [rdi], bl


### PR DESCRIPTION
## Summary
- fix jumps to `.ft_strcpy_null` so linker can resolve the label
- ignore build artifacts
- stop ignoring the `main` binary

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68717c767a248331a282476e1bc72f6c