### PR TITLE
Implement ft_strcmp in assembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AS      = as
 ASFLAGS = -g
 
 # List of all .asm sources
-SRCS    = main.asm strlen.asm strcpy.asm
+SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm
 OBJS    = $(SRCS:.asm=.o)
 
 # Name of the final executable

--- a/ft_strcmp.asm
+++ b/ft_strcmp.asm
@@ -1,0 +1,25 @@
+.intel_syntax noprefix
+.section .text
+.globl ft_strcmp
+
+ft_strcmp:
+.Lloop:
+        mov     al, byte ptr [rdi]
+        mov     bl, byte ptr [rsi]
+        cmp     al, bl
+        jne     .Ldiff
+        test    al, al
+        je      .Lequal
+        inc     rdi
+        inc     rsi
+        jmp     .Lloop
+
+.Ldiff:
+        movsx   eax, al
+        movsx   ebx, bl
+        sub     eax, ebx
+        ret
+
+.Lequal:
+        xor     eax, eax
+        ret

--- a/main.asm
+++ b/main.asm
@@ -4,6 +4,9 @@ msg:    .asciz  "Hello, world!\0"
 orig1:  .asciz  "first string\0"
 orig2:  .asciz  "second string\0"
 
+cmp_res1:       .long 0
+cmp_res2:       .long 0
+
         .lcomm  buf1, 32
         .lcomm  buf2, 32
 
@@ -13,6 +16,7 @@ orig2:  .asciz  "second string\0"
 
         .extern ft_strlen
         .extern ft_strcpy
+        .extern ft_strcmp
 
 strlen_test:
         lea     msg(%rip), %rdi
@@ -33,9 +37,24 @@ strcpy_test:
         ret
         .size   strcpy_test, .-strcpy_test
 
+strcmp_test:
+        lea     orig1(%rip), %rdi
+        lea     orig2(%rip), %rsi
+        call    ft_strcmp
+        mov     %eax, cmp_res1(%rip)
+
+        lea     orig1(%rip), %rdi
+        lea     orig1(%rip), %rsi
+        call    ft_strcmp
+        mov     %eax, cmp_res2(%rip)
+
+        ret
+        .size   strcmp_test, .-strcmp_test
+
 main:
         call    strlen_test
         call    strcpy_test
+        call    strcmp_test
         xor     %eax, %eax
         ret
         .size   main, .-main


### PR DESCRIPTION
## Summary
- add an assembly implementation of `ft_strcmp`
- compile `ft_strcmp.asm` in the build
- test `ft_strcmp` in `main`

## Testing
- `make clean && make`
- `./main` (no output expected)


------
https://chatgpt.com/codex/tasks/task_e_68718249ebac8331aed79ee457cf534b