### PR TITLE
Add ft_read syscall wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AS      = as
 ASFLAGS = -g
 
 # List of all .asm sources
-SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm
+SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm
 OBJS    = $(SRCS:.asm=.o)
 
 # Name of the final executable

--- a/ft_read.asm
+++ b/ft_read.asm
@@ -1,0 +1,17 @@
+.text
+.globl ft_read
+.type  ft_read, @function
+.extern __errno_location
+ft_read:
+    mov $0, %rax
+    syscall
+    cmp $0, %rax
+    jge .Ldone
+    neg %rax
+    mov %eax, %edi
+    call __errno_location
+    mov %edi, (%rax)
+    mov $-1, %rax
+.Ldone:
+    ret
+.size ft_read, .-ft_read

--- a/main.asm
+++ b/main.asm
@@ -11,8 +11,12 @@ write_ret:      .quad 0
 write_errno:    .long 0
 msg_len:        .long 0
 
+read_ret:       .quad 0
+read_errno:     .long 0
+
         .lcomm  buf1, 32
         .lcomm  buf2, 32
+        .lcomm  read_buf, 32
 
         .section .text
         .globl  main
@@ -22,6 +26,7 @@ msg_len:        .long 0
         .extern ft_strcpy
         .extern ft_strcmp
         .extern ft_write
+        .extern ft_read
 
 strlen_test:
         lea     msg(%rip), %rdi
@@ -78,11 +83,25 @@ write_test:
         ret
         .size   write_test, .-write_test
 
+read_test:
+        mov     $16, %edx              # count
+        lea     read_buf(%rip), %rsi   # buf
+        mov     $-1, %edi              # fd
+        call    ft_read
+        mov     %eax, read_ret(%rip)
+        call    __errno_location
+        mov     (%rax), %eax
+        mov     %eax, read_errno(%rip)
+
+        ret
+        .size   read_test, .-read_test
+
 main:
         call    strlen_test
         call    strcpy_test
         call    strcmp_test
         call    write_test
+        call    read_test
         xor     %eax, %eax
         ret
         .size   main, .-main


### PR DESCRIPTION
## Summary
- wrap `read(2)` in new `ft_read` assembly routine
- track new test data for `ft_read` in `main.asm`
- compile new object in the Makefile

## Testing
- `make clean && make`
- `./main`

------
https://chatgpt.com/codex/tasks/task_e_687203923da48331a3e109abb0bde406