### PR TITLE
Add ft_strdup implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AS      = as
 ASFLAGS = -g
 
 # List of all .asm sources
-SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm
+SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm ft_strdup.asm
 OBJS    = $(SRCS:.asm=.o)
 
 # Name of the final executable

--- a/ft_strdup.asm
+++ b/ft_strdup.asm
@@ -1,0 +1,30 @@
+.text
+.globl ft_strdup
+.type  ft_strdup, @function
+.extern ft_strlen
+.extern ft_strcpy
+.extern malloc
+.extern __errno_location
+
+ft_strdup:
+    push %rdi              # save source pointer
+    call ft_strlen         # rax = length of string
+    mov %rax, %rdx         # rdx = length
+    add $1, %rdx           # rdx = length + 1 (size to allocate)
+    mov %rdx, %rdi         # argument for malloc
+    call malloc
+    test %rax, %rax
+    je .Lmalloc_fail
+    mov %rax, %rdi         # dest pointer
+    pop %rsi               # restore source pointer into rsi
+    call ft_strcpy         # copy string
+    ret
+
+.Lmalloc_fail:
+    pop %rdi               # clean stack
+    mov $12, %edi          # ENOMEM
+    call __errno_location
+    mov %edi, (%rax)
+    xor %rax, %rax         # return NULL
+    ret
+.size ft_strdup, .-ft_strdup

--- a/main.asm
+++ b/main.asm
@@ -13,6 +13,7 @@ msg_len:        .long 0
 
 read_ret:       .quad 0
 read_errno:     .long 0
+dup_ptr:       .quad 0
 
         .lcomm  buf1, 32
         .lcomm  buf2, 32
@@ -27,6 +28,8 @@ read_errno:     .long 0
         .extern ft_strcmp
         .extern ft_write
         .extern ft_read
+        .extern ft_strdup
+        .extern free
 
 strlen_test:
         lea     msg(%rip), %rdi
@@ -96,12 +99,31 @@ read_test:
         ret
         .size   read_test, .-read_test
 
+strdup_test:
+        lea     orig1(%rip), %rdi
+        call    ft_strdup
+        mov     %rax, dup_ptr(%rip)
+        test    %rax, %rax
+        je      .Ldup_end
+        mov     %rax, %rdi
+        call    ft_strlen
+        mov     dup_ptr(%rip), %rsi
+        mov     %eax, %edx
+        mov     $1, %edi
+        call    ft_write
+        mov     dup_ptr(%rip), %rdi
+        call    free
+.Ldup_end:
+        ret
+        .size   strdup_test, .-strdup_test
+
 main:
         call    strlen_test
         call    strcpy_test
         call    strcmp_test
         call    write_test
         call    read_test
+        call    strdup_test
         xor     %eax, %eax
         ret
         .size   main, .-main


### PR DESCRIPTION
## Summary
- implement `ft_strdup` in assembly
- compile the new source by updating `Makefile`
- add simple test for `ft_strdup` in `main.asm`

## Testing
- `make clean && make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_687205fc75208331bc453afc0f9d4947