### PR TITLE
Remove comments from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,22 @@
-# ----- Makefile -----
 
-# Use GCC to link
 CC      = gcc
 CFLAGS  = -Wall -g
 
-# Use the assembler (as) to turn .asm into .o
 AS      = as
 ASFLAGS = -g
 
-# List of all .asm sources
 SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm ft_strdup.asm
 OBJS    = $(SRCS:.asm=.o)
 
-# Name of the final executable
 TARGET  = main
 
 .PHONY: all clean
 
 all: $(TARGET)
 
-# Link step: combine all .o files into 'main'
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS)
 
-# Generic rule: assemble each .asm into a .o
 %.o: %.asm
 	$(AS) $(ASFLAGS) -o $@ $<
 

--- a/ft_strdup.asm
+++ b/ft_strdup.asm
@@ -11,20 +11,20 @@ ft_strdup:
     call ft_strlen
     mov %rax, %rdx
     add $1, %rdx
-    mov %rdx, %rdi         # argument for malloc
+    mov %rdx, %rdi
     call malloc
     test %rax, %rax
     je .Lmalloc_fail
-    mov %rax, %rdi         # dest pointer
-    pop %rsi               # restore source pointer into rsi
-    call ft_strcpy         # copy string
+    mov %rax, %rdi
+    pop %rsi
+    call ft_strcpy
     ret
 
 .Lmalloc_fail:
-    pop %rdi               # clean stack
-    mov $12, %edi          # ENOMEM
+    pop %rdi
+    mov $12, %edi
     call __errno_location
     mov %edi, (%rax)
-    xor %rax, %rax         # return NULL
+    xor %rax, %rax
     ret
 .size ft_strdup, .-ft_strdup

--- a/main.asm
+++ b/main.asm
@@ -69,9 +69,9 @@ write_test:
         call    ft_strlen
         mov     %eax, msg_len(%rip)
 
-        mov     %eax, %edx              # count
-        lea     msg(%rip), %rsi         # buf
-        mov     $1, %edi                # fd
+        mov     %eax, %edx
+        lea     msg(%rip), %rsi
+        mov     $1, %edi
         call    ft_write
 
         mov     msg_len(%rip), %edx
@@ -87,9 +87,9 @@ write_test:
         .size   write_test, .-write_test
 
 read_test:
-        mov     $16, %edx              # count
-        lea     read_buf(%rip), %rsi   # buf
-        mov     $-1, %edi              # fd
+        mov     $16, %edx
+        lea     read_buf(%rip), %rsi
+        mov     $-1, %edi
         call    ft_read
         mov     %eax, read_ret(%rip)
         call    __errno_location


### PR DESCRIPTION
## Summary
- strip comments from ft_strdup.asm
- strip comments from main.asm
- strip comments from the Makefile

## Testing
- `make clean`
- `make`
- `./main`

------
https://chatgpt.com/codex/tasks/task_e_6872099c56b0833183244f1d7630ee69