### PR TITLE
Add ft_putnbr and display function results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS  = -Wall -g
 AS      = as
 ASFLAGS = -g
 
-SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm ft_strdup.asm
+SRCS    = main.asm strlen.asm strcpy.asm ft_strcmp.asm ft_write.asm ft_read.asm ft_strdup.asm ft_putnbr.asm
 OBJS    = $(SRCS:.asm=.o)
 
 TARGET  = main

--- a/ft_putnbr.asm
+++ b/ft_putnbr.asm
@@ -1,0 +1,38 @@
+.text
+.globl ft_putnbr
+.type  ft_putnbr, @function
+.extern ft_write
+ft_putnbr:
+    sub $40, %rsp
+    mov %rdi, %rax
+    lea 39(%rsp), %rsi
+    mov $0, %ecx
+    mov $10, %r9
+    xor %r8d, %r8d
+    test %rax, %rax
+    jge 1f
+    mov $1, %r8d
+    neg %rax
+1:
+2:
+    xor %rdx, %rdx
+    div %r9
+    add $'0', %dl
+    dec %rsi
+    mov %dl, (%rsi)
+    inc %ecx
+    test %rax, %rax
+    jne 2b
+    cmp $0, %r8d
+    je 3f
+    dec %rsi
+    mov $'-', %al
+    mov %al, (%rsi)
+    inc %ecx
+3:
+    mov %ecx, %edx
+    mov $1, %edi
+    call ft_write
+    add $40, %rsp
+    ret
+.size ft_putnbr, .-ft_putnbr

--- a/main.asm
+++ b/main.asm
@@ -4,6 +4,8 @@ msg:    .asciz  "Hello, world!\n"
 orig1:  .asciz  "first string\0"
 orig2:  .asciz  "second string\0"
 
+newline:        .byte 10
+
 cmp_res1:       .long 0
 cmp_res2:       .long 0
 
@@ -30,10 +32,18 @@ dup_ptr:       .quad 0
         .extern ft_read
         .extern ft_strdup
         .extern free
+        .extern ft_putnbr
 
 strlen_test:
         lea     msg(%rip), %rdi
         call    ft_strlen
+
+        mov     %rax, %rdi
+        call    ft_putnbr
+        mov     $1, %edx
+        lea     newline(%rip), %rsi
+        mov     $1, %edi
+        call    ft_write
 
         ret
         .size   strlen_test, .-strlen_test
@@ -56,10 +66,24 @@ strcmp_test:
         call    ft_strcmp
         mov     %eax, cmp_res1(%rip)
 
+        movsxd  %eax, %rdi
+        call    ft_putnbr
+        mov     $1, %edx
+        lea     newline(%rip), %rsi
+        mov     $1, %edi
+        call    ft_write
+
         lea     orig1(%rip), %rdi
         lea     orig1(%rip), %rsi
         call    ft_strcmp
         mov     %eax, cmp_res2(%rip)
+
+        movsxd  %eax, %rdi
+        call    ft_putnbr
+        mov     $1, %edx
+        lea     newline(%rip), %rsi
+        mov     $1, %edi
+        call    ft_write
 
         ret
         .size   strcmp_test, .-strcmp_test


### PR DESCRIPTION
## Summary
- add `ft_putnbr` helper using `ft_write`
- print `ft_strlen` and `ft_strcmp` results in `main`
- build the new file via Makefile

## Testing
- `make clean && make`
- `./main > /tmp/run_output.txt && cat /tmp/run_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_687229d3274c8331ad1e4ab4311fa595