### PR TITLE
Add fclean and re targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJS    = $(SRCS:.asm=.o)
 
 TARGET  = main
 
-.PHONY: all clean
+.PHONY: all clean fclean re
 
 all: $(TARGET)
 
@@ -21,4 +21,9 @@ $(TARGET): $(OBJS)
 	$(AS) $(ASFLAGS) -o $@ $<
 
 clean:
-	rm -f $(OBJS) $(TARGET)
+	rm -f $(OBJS)
+
+fclean: clean
+	rm -f $(TARGET)
+
+re: fclean all


### PR DESCRIPTION
## Summary
- add missing `fclean` and `re` targets
- ensure build commands are declared as phony

## Testing
- `make clean`
- `make`
- `make fclean`
- `make re`


------
https://chatgpt.com/codex/tasks/task_e_687249a890d08331a4081ba5c96e324f